### PR TITLE
Update syntax, fix bugs, use the logger

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,13 +12,14 @@ sanity.
  - copy `drools-engine.xml` to `$OPENNMS_HOME/etc/`
  - copy the entire `drools-engine.d` to `$OPENNMS_HOME/etc/`
  - modify the `drools-engine.xml` for your desired interval, event count, and event UEIs.
+ - add event defintions for the /Rollup events (i.e. uei.opennms.org/test/testtest1/Rollup)
  - cross your fingers and restart OpenNMS
 
 == Usage
-As described.  The log output from drools is eaten by systemd; you can view it 
-with `journalctl -u opennms`. The event parms from the triggering event are copied
-into the rollup event, so it would probably be helpful if all the event UEIs use
-the same parms and values, but we don't actually check for this.
+As described.  The log output from drools is written to logs/DroolsCorrelationEngine-*.log
+The event parms from the triggering event are copied into the rollup event, so it
+would probably be helpful if all the event UEIs use the same parms and values,
+but we don't actually check for this.
 
 == Questions?
 Ping @dino2gnt in https://chat.opennms.com/opennms/[the OpenNMS Mattermost chat]

--- a/drools-engine.d/eventCount.drl
+++ b/drools-engine.d/eventCount.drl
@@ -15,43 +15,42 @@ global java.lang.Integer EVENT_COUNT;
 global java.lang.Long EVENT_INTERVAL;
 global java.lang.String UEI;
 
+//
+// When we get a new event, create a 'Flap' object with a timer
+// since interface traps (or oper status poll) could refer to an interface without an IP
+// or come with event 'interface' of the loopback, we abuse the ipAddr field and add
+// parm values to it to keep the timer unique per interface
+//
 rule "Event received, create a flap timer if we dont have one"
     salience 100
     when
-        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
-        not $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
+        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
+        not $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1 )
     then
-        LOG.info( "Got an event: " + $uei + " for " + $nodeid + " " + $ipAddr );
-        insert ( createFlap(engine, $nodeid, $ipAddr, $svcName, -1, EVENT_INTERVAL ));
+        LOG.info( $uei + " " + $ipAddr+"_"+$snmpifname+"_"+$ifname );
+        insert ( createFlap(engine, $nodeid, $ipAddr+"_"+$snmpifname+"_"+$ifname, $svcName, -1, EVENT_INTERVAL ));
 end
 
+//
+// After we've created a 'Flap' object with a timer, we also need to create a 'FlapCount'
+// object to hold the number of times we've seen the event while the timer was active.
+// As before, we use parm values to help with traps/oper status polling uniqueness
+// A new counter starts with a value of 1, so we increment after we do other processing.
+//
 rule "Start a new flap count if we don't have one"
     salience 100
     when
-        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
-        $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
-        not FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
+        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
+        $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1 )
+        not FlapCount( nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1 )
     then
-        insert( new FlapCount( $nodeid, $ipAddr, $svcName, -1 ) );
+        insert( new FlapCount( $nodeid, $ipAddr+"_"+$snmpifname+"_"+$ifname, $svcName, -1 ) );
 end
 
-rule "start counting events"
-    // Counter starts set to 1, so we want to increment after we've checked the count
-    salience -100
-    lock-on-active true // really, don't run rules after we increment
-    when
-        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
-        $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
-        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1, $count : count )
-    then
-        modify( $eventCount ) {
-            // FlapCount starts with a count of 1, so we only need to increment after the first one
-            increment();
-        }
-        LOG.info( $uei + " count(" + $count + ") for " + $nodeid + " " + $ipAddr);
-        delete( $e ); // don't keep processing since we've pre-incremented the count
-end
-
+//
+// When a timer expires, we remove the Flap and FlapCount objects. Since we're setting $ipAddr
+// from the Flap object, we don't need to do anything special to get the string with parm values
+//
 rule "retract timer-expired counters"
     when
         $flap : Flap( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, $timerId : timerId )
@@ -61,19 +60,44 @@ rule "retract timer-expired counters"
         LOG.info( "Counter for " +$nodeid + ":" + $ipAddr + " has expired after " + EVENT_INTERVAL + "ms. ");
         delete( $flap );
         delete( $eventCount );
-        delete( $expiration );
 end
 
+//
+// Check the eventCount and see if we've crossed the threshold. We extract parm values from
+// the event as with the other rules to find a unique eventCount for an uei+interface
+//
 rule "flap count exceeded, send rollup event"
     when
-        $eventCount : FlapCount( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, alerted == false, count >= ( EVENT_COUNT ) )
-        $e : Event ( nodeid == $nodeid, interface == $ipAddr, service == $svcName )
+        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
+        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1, alerted == false, count >= ( EVENT_COUNT ) )
     then
         sendRollupEvent( engine, $e, EVENT_COUNT, EVENT_INTERVAL );
-        LOG.info("Event count(" + EVENT_COUNT  + ") exceeded for " + $e.getUei() + " " + $nodeid + " " + $ipAddr + ", sending rollup event");
+        LOG.info("Event count(" + EVENT_COUNT  + ") exceeded for " + $uei + " " + $ipAddr+"_"+$snmpifname+"_"+$ifname + ", sending rollup event");
         modify( $eventCount ) {
             setAlerted( true );
         }
+end
+
+//
+// After other processing, we grab an event and associated FlapCount, increment it and
+// then delete the event so it's not processed any more.
+//
+// lock-on-active shouldn't be necessary, but set it to be sure that we don't reactivate
+// any rules based on incrementing the counter here (they should activate the next time
+// an event comes in)
+//
+rule "increment event counter"
+    salience -100
+    lock-on-active true
+    when
+        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
+        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1, $count : count )
+    then
+        modify( $eventCount ) {
+            increment();
+        }
+        LOG.info( $uei + " " + $ipAddr+"_"+$snmpifname+"_"+$ifname + " count(" + $count + "++)" );
+        delete( $e );
 end
 
 //

--- a/drools-engine.d/eventCount.drl
+++ b/drools-engine.d/eventCount.drl
@@ -21,8 +21,8 @@ rule "Event received, create a flap timer if we dont have one"
         $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
         not $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
     then
-        LOG.info( "Got an event: " + $uei );
-        insert ( createFlap(engine, $nodeid, $ipAddr, $svcName, -1, EVENT_INTERVAL )); 
+        LOG.info( "Got an event: " + $uei + " for " + $nodeid + " " + $ipAddr );
+        insert ( createFlap(engine, $nodeid, $ipAddr, $svcName, -1, EVENT_INTERVAL ));
 end
 
 rule "Start a new flap count if we don't have one"
@@ -48,7 +48,7 @@ rule "start counting events"
             // FlapCount starts with a count of 1, so we only need to increment after the first one
             increment();
         }
-        LOG.info( $uei + " count(" + $count + ")");
+        LOG.info( $uei + " count(" + $count + ") for " + $nodeid + " " + $ipAddr);
         delete( $e ); // don't keep processing since we've pre-incremented the count
 end
 
@@ -67,10 +67,10 @@ end
 rule "flap count exceeded, send rollup event"
     when
         $eventCount : FlapCount( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, alerted == false, count >= ( EVENT_COUNT ) )
-        $e : Event()
+        $e : Event ( nodeid == $nodeid, interface == $ipAddr, service == $svcName )
     then
         sendRollupEvent( engine, $e, EVENT_COUNT, EVENT_INTERVAL );
-        LOG.info("Event count(" + EVENT_COUNT  + ") exceeded for " + $e.getUei() + ", sending rollup event");
+        LOG.info("Event count(" + EVENT_COUNT  + ") exceeded for " + $e.getUei() + " " + $nodeid + " " + $ipAddr + ", sending rollup event");
         modify( $eventCount ) {
             setAlerted( true );
         }

--- a/drools-engine.d/eventCount.drl
+++ b/drools-engine.d/eventCount.drl
@@ -22,13 +22,12 @@ global java.lang.String UEI;
 // parm values to it to keep the timer unique per interface
 //
 rule "Event received, create a flap timer if we dont have one"
-    salience 100
     when
         $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
         not $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1 )
     then
         LOG.info( $uei + " " + $ipAddr+"_"+$snmpifname+"_"+$ifname );
-        insert ( createFlap(engine, $nodeid, $ipAddr+"_"+$snmpifname+"_"+$ifname, $svcName, -1, EVENT_INTERVAL ));
+        insert ( createFlap(engine, $nodeid, $ipAddr+"_"+$snmpifname+"_"+$ifname, $svcName, -1, EVENT_INTERVAL) );
 end
 
 //
@@ -38,7 +37,6 @@ end
 // A new counter starts with a value of 1, so we increment after we do other processing.
 //
 rule "Start a new flap count if we don't have one"
-    salience 100
     when
         $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
         $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1 )
@@ -54,7 +52,7 @@ end
 rule "retract timer-expired counters"
     when
         $flap : Flap( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, $timerId : timerId )
-        $expiration: TimerExpired( id == $timerId )
+        $expiration : TimerExpired( id == $timerId )
         $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName,  locationMonitor == -1 )
     then
         LOG.info( "Counter for " +$nodeid + ":" + $ipAddr + " has expired after " + EVENT_INTERVAL + "ms. ");
@@ -63,49 +61,49 @@ rule "retract timer-expired counters"
 end
 
 //
-// Check the eventCount and see if we've crossed the threshold. We extract parm values from
-// the event as with the other rules to find a unique eventCount for an uei+interface
+// Count the event (case when we haven't sent an alert)
 //
-rule "flap count exceeded, send rollup event"
+rule "count the event"
     when
         $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
-        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1, alerted == false, count >= ( EVENT_COUNT ) )
+        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1, count < ( EVENT_COUNT ), alerted == false, $count : count )
     then
-        sendRollupEvent( engine, $e, EVENT_COUNT, EVENT_INTERVAL );
-        LOG.info("Event count(" + EVENT_COUNT  + ") exceeded for " + $uei + " " + $ipAddr+"_"+$snmpifname+"_"+$ifname + ", sending rollup event");
-        modify( $eventCount ) {
-            setAlerted( true );
-        }
-        // if EVENT_COUNT is 1 and EVENT_INTERVAL is long, we need to delete the event here, because otherwise the FlapCount will expire before we
-        // increment and delete the event. This will cause us to send the Rollup over and over
-        // We don't care if the $count is inaccurate during the rest of EVENT_INTERVAL because we've already sent the Rollup
-        delete( $e );
-end
-
-//
-// After other processing, we grab an event and associated FlapCount, increment it and
-// then delete the event so it's not processed any more.
-//
-// lock-on-active shouldn't be necessary, but set it to be sure that we don't reactivate
-// any rules based on incrementing the counter here (they should activate the next time
-// an event comes in)
-//
-rule "increment event counter"
-    salience -100
-    lock-on-active true
-    when
-        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
-        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1, $count : count )
-    then
+        LOG.info( $uei + " " + $ipAddr+"_"+$snmpifname+"_"+$ifname + " count(" + $count + "++)" );
         modify( $eventCount ) {
             increment();
         }
-        LOG.info( $uei + " " + $ipAddr+"_"+$snmpifname+"_"+$ifname + " count(" + $count + "++)" );
         delete( $e );
 end
 
 //
-// Builds the rollup event to emit when the count is exceeded
+// Send an alert
+//
+rule "send an alert"
+    when
+        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
+        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1, count >= ( EVENT_COUNT ), alerted == false )
+    then
+        sendRollupEvent( engine, $e, EVENT_COUNT, EVENT_INTERVAL );
+        modify( $eventCount ) {
+            setAlerted( true );
+        }
+        delete( $e );
+end
+
+//
+// Process the event after the alert
+//
+rule "delete the event if we have alerted"
+    when
+        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service, $ifname : getParm("ifName"), $snmpifname : getParm("snmpifname") )
+        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr+"_"+$snmpifname+"_"+$ifname, svcName == $svcName, locationMonitor == -1, alerted == true )
+    then
+        LOG.info( $uei + " " + $ipAddr+"_"+$snmpifname+"_"+$ifname + " ... already alerted." );
+        delete( $e );
+end
+
+//
+// Builds and sends the rollup event
 //
 function void sendRollupEvent(DroolsCorrelationEngine engine, Event e, Integer count, Long interval) {
     EventBuilder bldr = new EventBuilder(e.getUei() + "/Rollup", "DroolsEventAccumulator")

--- a/drools-engine.d/eventCount.drl
+++ b/drools-engine.d/eventCount.drl
@@ -71,20 +71,18 @@ rule "flap count exceeded, send rollup event"
     then
         sendRollupEvent( engine, $e, EVENT_COUNT, EVENT_INTERVAL );
         LOG.info("Event count(" + EVENT_COUNT  + ") exceeded for " + $e.getUei() + ", sending rollup event");
-        delete( $e );
         modify( $eventCount ) {
             setAlerted( true );
         }
 end
 
-rule "rollup event already sent, delete event"
+rule "delete the event after processing"
     salience -100
     when
-        $eventCount : FlapCount( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, alerted == true )
         $e : Event( $uei : uei )
     then
         delete( $e ); // we want to just drop this so we don't keep processing it
-        LOG.info ( "Got " + $uei + " but we already sent rollup event, discarding." );
+        LOG.info ( "Deleting " + $uei + " so we don't process it more than once." );
 end
 
 //

--- a/drools-engine.d/eventCount.drl
+++ b/drools-engine.d/eventCount.drl
@@ -1,16 +1,12 @@
-
 package org.opennms.netmgt.correlation.drools;
 
 import java.util.Date;
 
-//import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Parm;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
-import org.drools.core.spi.KnowledgeHelper;
-
 
 global org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine engine;
 global org.slf4j.Logger LOG;
@@ -20,97 +16,90 @@ global java.lang.Long EVENT_INTERVAL;
 global java.lang.String UEI;
 
 rule "Event received, create a flap timer if we dont have one"
-	salience 100
-	when
-                $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
-                not $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 );
-	then
-		retract( $e );
-                println( "Got an event: " + $uei );
-		insert ( createFlap(engine, $nodeid, $ipAddr, $svcName, -1, EVENT_INTERVAL )); 
+    salience 100
+    when
+        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
+        not $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
+    then
+        LOG.info( "Got an event: " + $uei );
+        insert ( createFlap(engine, $nodeid, $ipAddr, $svcName, -1, EVENT_INTERVAL )); 
 end
 
 rule "Start a new flap count if we don't have one"
-        salience 100
-        when
-                $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
-		$flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 );
-		not FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 );
-
-        then
-                insert( new FlapCount( $nodeid, $ipAddr, $svcName, -1 ) );
-                update( $flap );
-                retract( $e );
+    salience 100
+    when
+        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
+        $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
+        not FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
+    then
+        insert( new FlapCount( $nodeid, $ipAddr, $svcName, -1 ) );
+        delete( $e ); // shortcut here - we'll have a FlapCount of 1 already so we don't need to increment
 end
 
 rule "start counting events"
-        salience 100
-        lock-on-active true
-        when
-                $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
-                $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 );
-                $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1, $count : count );
-        then
-                $eventCount.increment();
-                println($uei + " count(" + $count + ")");
-                update( $eventCount );
-                update( $flap );
-
-end
-
-//Not currently used
-//
-rule "resolving event received while timer active"
-	when
-		$e : Event( uei == "uei.opennms.org/correlation/testtestResolved", $nodeid : nodeid, $ipAddr : interface, $svcName : service )
-                $flap: Flap( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1, endTime == null )
-                $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName,  locationMonitor == -1 )
-	then
-		$flap.setEndTime( new Date() );
-		$eventCount.setCount(0);
-		update( $flap );
-		println(" Monitor has reported up for " + $e );
-		retract( $e );
+    salience 100
+    no-loop true
+    when
+        $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
+        $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
+        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1, $count : count )
+    then
+        modify( $eventCount ) {
+            // FlapCount starts with a count of 1, so we only need to increment after the first one
+            increment();
+        }
+        LOG.info( $uei + " count(" + ($count+1) + ")");
+        update( $eventCount );
 end
 
 rule "retract timer-expired counters"
-	when
-		$flap : Flap( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, $timerId : timerId )
-		$expiration: TimerExpired( id == $timerId )
-		$eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName,  locationMonitor == -1 )
-	then
-		println( "Counter for " +$nodeid + ":" + $ipAddr + " has expired after " + EVENT_INTERVAL + "ms. ");
-		retract( $flap );
-		retract( $eventCount );
-		retract( $expiration );
+    when
+        $flap : Flap( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, $timerId : timerId )
+        $expiration: TimerExpired( id == $timerId )
+        $eventCount : FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName,  locationMonitor == -1 )
+    then
+        LOG.info( "Counter for " +$nodeid + ":" + $ipAddr + " has expired after " + EVENT_INTERVAL + "ms. ");
+        delete( $flap );
+        delete( $eventCount );
+        delete( $expiration );
 end
 
 rule "flap count exceeded, send rollup event"
-	when
-		$eventCount : FlapCount( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, alerted == false, count >= ( EVENT_COUNT ) )
-                $e : Event()
-	then
-		sendRollupEvent( engine, $e, EVENT_COUNT, EVENT_INTERVAL );
-		println("Event count(" + EVENT_COUNT  + ") exceeded for " + $e.getUei() + ", sending rollup event");
-                retract( $e );
-		$eventCount.setAlerted( true );
-		update( $eventCount );
+    when
+        $eventCount : FlapCount( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, alerted == false, count >= ( EVENT_COUNT ) )
+        $e : Event()
+    then
+        sendRollupEvent( engine, $e, EVENT_COUNT, EVENT_INTERVAL );
+        LOG.info("Event count(" + EVENT_COUNT  + ") exceeded for " + $e.getUei() + ", sending rollup event");
+        delete( $e );
+        modify( $eventCount ) {
+            setAlerted( true );
+        }
+end
+
+rule "rollup event already sent, delete event"
+    salience -100
+    when
+        $eventCount : FlapCount( $nodeid : nodeid, $ipAddr : ipAddr, $svcName : svcName, locationMonitor == -1, alerted == true )
+        $e : Event( $uei : uei )
+    then
+        delete( $e ); // we want to just drop this so we don't keep processing it
+        LOG.info ( "Got " + $uei + " but we already sent rollup event, discarding." );
 end
 
 //
 // Builds the rollup event to emit when the count is exceeded
 //
 function void sendRollupEvent(DroolsCorrelationEngine engine, Event e, Integer count, Long interval) {
-	EventBuilder bldr = new EventBuilder(e.getUei() + "Rollup", "DroolsEventAccumulator")
-		.setNodeid(e.getNodeid())
-		.setInterface(e.getInterfaceAddress())
-		.setService(e.getService());
-                copyParms(e, bldr);
-                bldr.addParam("rolledUpUEI", e.getUei())
-                .addParam("eventCount", count)
-                .addParam("interval", interval);
-	engine.sendEvent(bldr.getEvent());
-
+    EventBuilder bldr = new EventBuilder(e.getUei() + "/Rollup", "DroolsEventAccumulator")
+        .setNodeid(e.getNodeid())
+        .setInterface(e.getInterfaceAddress())
+        .setService(e.getService());
+        copyParms(e, bldr);
+        bldr.addParam("rolledUpUEI", e.getUei())
+        .addParam("eventCount", count)
+        .addParam("interval", interval);
+    engine.sendEvent(bldr.getEvent());
 }
 
 //
@@ -128,10 +117,3 @@ function void copyParms(Event sourceEvent, EventBuilder targetEventBuilder) {
         targetEventBuilder.addParam(p);
     }
 }
-//
-// Just for convenience
-//
-function void println(Object msg) {
-	System.out.println(new Date()+" : "+msg);
-}
-

--- a/drools-engine.d/eventCount.drl
+++ b/drools-engine.d/eventCount.drl
@@ -76,6 +76,10 @@ rule "flap count exceeded, send rollup event"
         modify( $eventCount ) {
             setAlerted( true );
         }
+        // if EVENT_COUNT is 1 and EVENT_INTERVAL is long, we need to delete the event here, because otherwise the FlapCount will expire before we
+        // increment and delete the event. This will cause us to send the Rollup over and over
+        // We don't care if the $count is inaccurate during the rest of EVENT_INTERVAL because we've already sent the Rollup
+        delete( $e );
 end
 
 //

--- a/drools-engine.d/eventCount.drl
+++ b/drools-engine.d/eventCount.drl
@@ -33,12 +33,11 @@ rule "Start a new flap count if we don't have one"
         not FlapCount( nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
     then
         insert( new FlapCount( $nodeid, $ipAddr, $svcName, -1 ) );
-        delete( $e ); // shortcut here - we'll have a FlapCount of 1 already so we don't need to increment
 end
 
 rule "start counting events"
-    salience 100
-    no-loop true
+    // Counter starts set to 1, so we want to increment after we've checked the count
+    salience -100
     when
         $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
         $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )
@@ -48,8 +47,8 @@ rule "start counting events"
             // FlapCount starts with a count of 1, so we only need to increment after the first one
             increment();
         }
-        LOG.info( $uei + " count(" + ($count+1) + ")");
-        update( $eventCount );
+        LOG.info( $uei + " count(" + $count + ")");
+        delete( $e ); // don't keep processing since we've pre-incremented the count
 end
 
 rule "retract timer-expired counters"
@@ -74,15 +73,6 @@ rule "flap count exceeded, send rollup event"
         modify( $eventCount ) {
             setAlerted( true );
         }
-end
-
-rule "delete the event after processing"
-    salience -100
-    when
-        $e : Event( $uei : uei )
-    then
-        delete( $e ); // we want to just drop this so we don't keep processing it
-        LOG.info ( "Deleting " + $uei + " so we don't process it more than once." );
 end
 
 //

--- a/drools-engine.d/eventCount.drl
+++ b/drools-engine.d/eventCount.drl
@@ -38,6 +38,7 @@ end
 rule "start counting events"
     // Counter starts set to 1, so we want to increment after we've checked the count
     salience -100
+    lock-on-active // really, don't run rules after we increment
     when
         $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
         $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )

--- a/drools-engine.d/eventCount.drl
+++ b/drools-engine.d/eventCount.drl
@@ -38,7 +38,7 @@ end
 rule "start counting events"
     // Counter starts set to 1, so we want to increment after we've checked the count
     salience -100
-    lock-on-active // really, don't run rules after we increment
+    lock-on-active true // really, don't run rules after we increment
     when
         $e : Event( $uei : uei, $nodeid : nodeid, $ipAddr : interface, $svcName : service )
         $flap : Flap(nodeid == $nodeid, ipAddr == $ipAddr, svcName == $svcName, locationMonitor == -1 )


### PR DESCRIPTION
- Update README
- remove broken import
- remove unused rule
- switch println to LOG
- s/retract/delete
- remove updates where we didn't update something
- use modify() instead of update
- no-loop instead of lock-on-active
- add rule to discard events while the timer is active but the rollup was sent
- use /Rollup instead of Rollup to append to UEI
- use Unix line breaks and spaces instead of mix of tabs and spaces
- try to be more consistent with ; use (never use it for when, always for then)